### PR TITLE
remove redundant prints

### DIFF
--- a/lib/flutter_html_text.dart
+++ b/lib/flutter_html_text.dart
@@ -51,6 +51,7 @@ class HtmlText extends StatelessWidget {
     ctx = context;
     HtmlParser parser = new HtmlParser();
     List nodes = parser.parse(this.data);
+
     TextSpan span = this._stackToTextSpan(nodes, context);
     RichText contents = new RichText(
       text: span,
@@ -79,8 +80,13 @@ class HtmlText extends StatelessWidget {
   TextSpan _textSpan(Map node) {
     TextSpan span;
     String s = node['text'];
+
     s = s.replaceAll('\u00A0', ' ');
     s = s.replaceAll('&nbsp;', ' ');
+    s = s.replaceAll('&amp;', '&');
+    s = s.replaceAll('&lt;', '<');
+    s = s.replaceAll('&gt;', '>');
+
     if (node['tag'] == 'a') {
       span = new TextSpan(
           text: s, style: node['style'], recognizer: recognizer(node['href']));

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -40,9 +40,7 @@ class HtmlParser {
         !e.outerHtml.contains("<video") ||
         !e.hasContent()) {
       widgetList.add(new HtmlText(data: e.outerHtml));
-    }
-
-    if (e.children.length > 0)
+    } else if (e.children.length > 0)
       e.children.forEach((e) => _parseChildren(e, widgetList));
   }
 

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -11,7 +11,6 @@ class HtmlParser {
   HtmlParser();
 
   _parseChildren(e, widgetList) {
-    print(e);
     if (e.localName == "img" && e.attributes.containsKey('src')) {
       var src = e.attributes['src'];
 
@@ -40,7 +39,6 @@ class HtmlParser {
     } else if (!e.outerHtml.contains("<img") ||
         !e.outerHtml.contains("<video") ||
         !e.hasContent()) {
-      print(e.outerHtml);
       widgetList.add(new HtmlText(data: e.outerHtml));
     }
 


### PR DESCRIPTION
Html parser printed some html strings (probably for debugging). We've removed them in our fork to reduce verbosity.