### PR TITLE
Added cache image network fork

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,9 @@ dependencies:
 
   flutter_custom_tabs: "^0.3.0"
   html: "^0.13.3"
-  cached_network_image: "^0.4.1"
+  cached_network_image:
+    git:
+      url: https://github.com/jogboms/flutter_cached_network_image.git
   video_player: "^0.6.4"
 
 


### PR DESCRIPTION
Updated `cached_network_image`library dependency.

Because the cached_network_image library is not ready for Dart 2.1, I use a fork