### PR TITLE
use offical flutter_custom_tabs pub

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,8 +12,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_custom_tabs:
-    git: git://github.com/ohze/flutter_custom_tabs.git
+  flutter_custom_tabs: ^0.6.0
 
   flutter_html_view:
     path: ../

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,7 @@ homepage: https://github.com/PonnamKarthik/FlutterHtmlView
 dependencies:
   flutter:
     sdk: flutter
-  flutter_custom_tabs:
-    git: git://github.com/ohze/flutter_custom_tabs.git
+  flutter_custom_tabs: ^0.6.0
   html: ^0.13.3+3
   video_player: 0.10.0+2
   cached_network_image: ^0.6.0+1


### PR DESCRIPTION
flutter_custom_tabs >= 0.5.0 now support AndroidX,
so we don't need fork flutter_custom_tabs & use `git:` dependency anymore