### PR TITLE
cached_network_image: ^1.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter_custom_tabs: ^0.6.0
   html: ^0.13.3+3
   video_player: 0.10.0+2
-  cached_network_image: ^0.7.0
+  cached_network_image: ^1.1.1
 
   flutter_markdown: ^0.2.0
   html2md: ^0.3.0


### PR DESCRIPTION
update **cached_network_image** latest version.

because it get exception

```
Compiler message:
cached_network_image.dart:199:38: Error: The argument type 'void Function(ImageInfo, bool)' can't be assigned to the parameter type 'ImageStreamListener'.
 - 'ImageInfo' is from 'package:flutter/src/painting/image_stream.dart' ('file:///Library/Flutter/packages/flutter/lib/src/painting/image_stream.dart').
 - 'ImageStreamListener' is from 'package:flutter/src/painting/image_stream.dart' ('file:///Library/Flutter/packages/flutter/lib/src/painting/image_stream.dart').
Try changing the type of the parameter, or casting the argument to 'ImageStreamListener'.
      oldImageStream?.removeListener(_handleImageChanged);
                                     ^
cached_network_image.dart:200:32: Error: The argument type 'void Function(ImageInfo, bool)' can't be assigned to the parameter type 'ImageStreamListener'.
 - 'ImageInfo' is from 'package:flutter/src/painting/image_stream.dart' ('file:///Library/Flutter/packages/flutter/lib/src/painting/image_stream.dart').
 - 'ImageStreamListener' is from 'package:flutter/src/painting/image_stream.dart' ('file:///Library/Flutter/packages/flutter/lib/src/painting/image_stream.dart').
Try changing the type of the parameter, or casting the argument to 'ImageStreamListener'.
      _imageStream.addListener(_handleImageChanged);
                               ^
cached_network_image.dart:210:34: Error: The argument type 'void Function(ImageInfo, bool)' can't be assigned to the parameter type 'ImageStreamListener'.
 - 'ImageInfo' is from 'package:flutter/src/painting/image_stream.dart' ('file:///Library/Flutter/packages/flutter/lib/src/painting/image_stream.dart').
 - 'ImageStreamListener' is from 'package:flutter/src/painting/image_stream.dart' ('file:///Library/Flutter/packages/flutter/lib/src/painting/image_stream.dart').
Try changing the type of the parameter, or casting the argument to 'ImageStreamListener'.
    _imageStream?.removeListener(_handleImageChanged);
                                 ^
/.pub-cache/hosted/pub.dartlang.org/cached_network_image-0.4.2/lib/cached_network_image.dart:464:31: Error: The argument type 'Null Function(StringBuffer)' can't be assigned to the parameter type 'Iterable<DiagnosticsNode> Function()'.
 - 'StringBuffer' is from 'dart:core'.
 - 'Iterable' is from 'dart:core'.
 - 'DiagnosticsNode' is from 'package:flutter/src/foundation/diagnostics.dart' ('file:///Library/Flutter/packages/flutter/lib/src/foundation/diagnostics.dart').
Try changing the type of the parameter, or casting the argument to 'Iterable<DiagnosticsNode> Function()'.
        informationCollector: (StringBuffer information) {
                              ^
Compiler failed on /.../lib/main.dart
Error launching application on iPhone Xʀ.
```
